### PR TITLE
feat(claude): add Claude LLM integration and documentation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,6 +13,7 @@ env/
 .idea/
 .vscode/
 *.swp
+*.swo
 
 # OS
 .DS_Store
@@ -32,6 +33,10 @@ logs/
 coverage/
 .coverage
 .pytest_cache/
+
+# Claude working files
+docs/claude/scratch/
+scratch/
 
 # Project specific
 # [ADD YOUR PROJECT'S SPECIFIC IGNORES HERE]

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,96 @@
+# CLAUDE.md - S.C.O.P.E. LLM Integration Guide
+
+## Project Overview
+
+**S.C.O.P.E.** (System Coordination, Orchestration, Planning & Execution) is the meta-repository coordinating the O.A.S.I.S. ecosystem - an open-source Iron Man-style AI assistant and HUD project.
+
+## Repository Purpose
+
+This is a **coordination repository**, not a code repository. It will:
+- Track roadmaps across multiple component repos
+- Provide unified documentation and getting-started guides
+- Contain templates for repository standardization
+- House Docker configurations for development environments
+
+## Current State
+
+Currently implemented:
+- Component repository submodules under `repos/`
+- This LLM integration guide (`CLAUDE.md`)
+
+Planned directories (coming soon):
+- `coordination/roadmaps/` - Per-repo development roadmaps
+- `coordination/dependencies/` - Cross-repo dependency documentation
+- `coordination/hardware-guides/` - Hardware progression paths
+- `getting-started/` - Platform-specific setup guides
+- `templates/docker/` - Docker configuration templates
+- `templates/oasis-foundation/` - Repository standardization templates
+
+## O.A.S.I.S. Component Repositories
+
+Available as submodules under `repos/`:
+
+| Repo | Purpose | Primary Language | Hardware |
+|------|---------|------------------|----------|
+| MIRAGE | HUD display | C | Display, cameras |
+| DAWN | AI assistant | C++/Python | Audio, compute |
+| SPARK | Hand firmware | C | SPI/I2C sensors |
+| AURA | Helmet firmware | C | Sensors, LEDs |
+| BEACON | CAD models | N/A | 3D printing |
+| GENESIS | Python utilities | Python | N/A |
+
+## Cross-Repo Relationships
+
+```
+GENESIS (utilities)
+    |
+    v
+DAWN (AI) <--MQTT--> MIRAGE (HUD)
+    |                    |
+    v                    v
+  SPARK <---MQTT---> AURA (firmware)
+                        |
+                        v
+                   BEACON (CAD)
+```
+
+Communication between components uses **MQTT** messaging.
+
+## Hardware Platforms
+
+| Platform | Key Specs | Best For |
+|----------|-----------|----------|
+| Raspberry Pi 4/5 | ARM64, 4-8GB RAM | Entry-level, learning |
+| Orin Nano | 6 TOPS AI, 8GB RAM | Development, testing |
+| Jetson NX | 21 TOPS AI, 16GB RAM | Full deployment |
+
+## Working with This Repository
+
+### Do
+- Keep documentation synchronized across repos
+- Update dependency graphs when relationships change
+- Test Docker configurations on target platforms
+- Maintain consistent file structures
+
+### Don't
+- Put component-specific code here (goes in component repos)
+- Duplicate documentation that exists in component repos
+- Make breaking changes to templates without coordination
+
+## Documentation Architecture
+
+S.C.O.P.E. is the **middle tier** in O.A.S.I.S. documentation:
+
+| Tier | Repository | Purpose |
+|------|------------|---------|
+| Portal | The-OASIS-Project.github.io | Public-facing MkDocs site |
+| Coordination | S.C.O.P.E. (this repo) | Developer guides, templates |
+| Components | MIRAGE, DAWN, etc. | Code and component docs |
+
+The .github.io site compiles user-facing content from S.C.O.P.E. via MkDocs.
+
+## Related Resources
+
+- [The-OASIS-Project.github.io](https://github.com/The-OASIS-Project/The-OASIS-Project.github.io) - Public documentation portal
+- [Project Foundation Template](https://github.com/malcolmhoward/project-foundation-template) - Governance templates
+- [The O.A.S.I.S. Project](https://github.com/The-OASIS-Project) - Main organization

--- a/README.md
+++ b/README.md
@@ -2,16 +2,52 @@
 
 **System Coordination, Orchestration, Planning & Execution**
 
-> Coordinates cross-repo automation, documentation, and planning across the [O.A.S.I.S. project](https://github.com/The-OASIS-Project).
+Meta-repository for coordinating the [O.A.S.I.S. Project](https://github.com/The-OASIS-Project) ecosystem.
 
-## Overview
+## What is S.C.O.P.E.?
 
-S.C.O.P.E. is the meta-repository for the O.A.S.I.S. project ecosystem. It provides centralized coordination for:
+S.C.O.P.E. serves as the central coordination point for the Open-source Assistive System for Integrated Services (O.A.S.I.S.) project. It will provide:
 
-- Cross-repository automation and workflows
-- Unified documentation and standards
-- Planning and project management
-- Integration between O.A.S.I.S. components
+- **Unified documentation** across all O.A.S.I.S. components
+- **Getting started guides** for different hardware platforms
+- **Hardware guides** showing hardware progression paths
+- **Cross-project coordination** for roadmaps and dependencies
+- **Docker orchestration** for multi-component development
+- **Foundation templates** for repository standardization
+
+## Documentation Architecture
+
+O.A.S.I.S. documentation follows a three-tier architecture:
+
+```
+┌─────────────────────────────────────────────────────────────────┐
+│            The-OASIS-Project.github.io (Public Portal)          │
+│  • Landing page & project overview                              │
+│  • User-facing getting started guides                           │
+│  • Feature demos & showcase                                     │
+│  • Compiles content from S.C.O.P.E. via MkDocs                 │
+└─────────────────────────┬───────────────────────────────────────┘
+                          │ compiles from
+┌─────────────────────────▼───────────────────────────────────────┐
+│                S.C.O.P.E. (Coordination Hub)                    │
+│  • Hardware guides (hardware-guides/)                           │
+│  • Platform setup guides (getting-started/)                     │
+│  • Cross-repo roadmaps & dependencies                           │
+│  • Standardization templates for component repos                │
+└─────────────────────────┬───────────────────────────────────────┘
+                          │ coordinates
+┌─────────────────────────▼───────────────────────────────────────┐
+│              Component Repos (Authoritative Source)             │
+│  MIRAGE │ DAWN │ SPARK │ AURA │ BEACON │ GENESIS               │
+│  Each repo owns: README, CLAUDE.md, Dockerfiles, code docs     │
+└─────────────────────────────────────────────────────────────────┘
+```
+
+| Tier | Repository | Audience | Content |
+|------|------------|----------|---------|
+| Portal | [The-OASIS-Project.github.io](https://github.com/The-OASIS-Project/The-OASIS-Project.github.io) | End users | Polished guides, demos |
+| Coordination | S.C.O.P.E. (this repo) | Developers | Hardware paths, templates |
+| Components | MIRAGE, DAWN, etc. | Contributors | Code, component docs |
 
 ## Repository Structure
 
@@ -29,6 +65,50 @@ repos/
   project-foundation-template/  # PFT governance tooling (v3.7.0)
 ```
 
+## What is O.A.S.I.S.?
+
+O.A.S.I.S. (Open-source Assistive System for Integrated Services) is an open-source project building an Iron Man-style AI assistant and heads-up display (HUD) system.
+
+### Component Repositories
+
+| Repository | Description | Language |
+|------------|-------------|----------|
+| [MIRAGE](https://github.com/The-OASIS-Project/mirage) | HUD display system | C |
+| [DAWN](https://github.com/The-OASIS-Project/dawn) | AI voice assistant | C++ / Python |
+| [SPARK](https://github.com/The-OASIS-Project/spark) | Hand/gauntlet firmware | C |
+| [AURA](https://github.com/The-OASIS-Project/aura) | Helmet sensor firmware | C |
+| [BEACON](https://github.com/The-OASIS-Project/beacon) | CAD models and designs | N/A |
+| [GENESIS](https://github.com/The-OASIS-Project/genesis) | Python utilities | Python |
+
+All component repositories are available as submodules under `repos/`.
+
+## Current Status
+
+This repository is under active development. Currently implemented:
+
+- [x] Component repository submodules
+- [x] Claude LLM integration guide (`CLAUDE.md`)
+
+Coming soon:
+
+- [ ] Directory structure for coordination
+- [ ] Foundation templates for repo standardization
+- [ ] Hardware guides (platform comparison, costs)
+- [ ] Getting started guides per platform
+- [ ] Docker orchestration
+
+## Feature Matrix
+
+| Feature | Raspberry Pi | Orin Nano | Jetson NX |
+|---------|:------------:|:---------:|:---------:|
+| Basic HUD | Yes | Yes | Yes |
+| Camera input | Yes | Yes | Yes |
+| Stereo vision | Limited | Yes | Yes |
+| Voice recognition | Limited | Yes | Yes |
+| Local LLM | No | Limited | Yes |
+| Full DAWN AI | No | Limited | Yes |
+| Sensor suite | Yes | Yes | Yes |
+
 ## Getting Started
 
 ```bash
@@ -43,9 +123,28 @@ git submodule update --init --recursive
 
 Please see [CONTRIBUTING.md](CONTRIBUTING.md) for guidelines.
 
+### Standardization
+
+All O.A.S.I.S. repositories should include:
+- `README.md` - Project overview
+- `CONTRIBUTING.md` - Contribution guidelines
+- `CLAUDE.md` - LLM integration guidance
+- `GETTING_STARTED.md` - Quick start for that component
+
+## Related Projects
+
+- [The-OASIS-Project.github.io](https://github.com/The-OASIS-Project/The-OASIS-Project.github.io) - Public documentation portal (MkDocs site)
+- [Project Foundation Template](https://github.com/malcolmhoward/project-foundation-template) - Governance templates used to standardize O.A.S.I.S. repos
+
 ## License
 
 This project is licensed under the GNU General Public License v3.0 - see [LICENSE](LICENSE) file.
+
+## Acknowledgments
+
+- [The O.A.S.I.S. Project](https://github.com/The-OASIS-Project) and Kris Kersey for creating this vision
+- All contributors to the O.A.S.I.S. ecosystem
+- The open-source hardware and maker communities
 
 ---
 

--- a/claude/README.md
+++ b/claude/README.md
@@ -1,0 +1,44 @@
+# Claude Integration
+
+This directory contains resources for Claude LLM integration with the O.A.S.I.S. project.
+
+## Contents
+
+| File | Purpose |
+|------|---------|
+| `README.md` | This file |
+| `prompts/` | Example prompts for common tasks |
+
+## Usage
+
+Claude can assist with O.A.S.I.S. development in several ways:
+
+### Code Assistance
+- Understanding component architecture
+- Debugging hardware integration issues
+- Writing documentation
+
+### Project Coordination
+- Summarizing issues across repos
+- Planning sprint work
+- Reviewing cross-repo dependencies
+
+### Documentation
+- Generating getting-started guides
+- Updating changelogs
+- Creating API documentation
+
+## CLAUDE.md Files
+
+Each O.A.S.I.S. repository should include a `CLAUDE.md` file that provides:
+- Project-specific context
+- Key files and their purposes
+- Common development tasks
+- Build and test commands
+
+See the root `CLAUDE.md` for the S.C.O.P.E. meta-repo context.
+
+## Related
+
+- [/CLAUDE.md](/CLAUDE.md) - S.C.O.P.E. LLM integration guide
+- [templates/oasis-foundation/CLAUDE-template.md](/templates/oasis-foundation/CLAUDE-template.md) - Template for component repos

--- a/claude/prompts/issue-summary.md
+++ b/claude/prompts/issue-summary.md
@@ -1,0 +1,40 @@
+# Issue Summary Prompt
+
+Use this prompt to get Claude to summarize open issues across O.A.S.I.S. repositories.
+
+## Prompt
+
+```
+Please summarize the open issues in the O.A.S.I.S. project repositories.
+
+For each repository, list:
+1. Number of open issues
+2. Key themes or categories
+3. Any blockers or high-priority items
+
+Repositories to check:
+- malcolmhoward/the-oasis-project-meta-repo (S.C.O.P.E.)
+- malcolmhoward/mirage
+- malcolmhoward/dawn
+- malcolmhoward/spark
+- malcolmhoward/aura
+- malcolmhoward/beacon
+- malcolmhoward/genesis
+
+Format the output as a table with columns:
+| Repo | Open Issues | Key Themes | Priority Items |
+```
+
+## Usage
+
+This prompt works best when Claude has access to:
+- GitHub CLI (`gh issue list`)
+- Repository access via submodules
+
+## Example Output
+
+| Repo | Open Issues | Key Themes | Priority Items |
+|------|-------------|------------|----------------|
+| S.C.O.P.E. | 21 | Setup, Docs, Docker | Foundation templates |
+| MIRAGE | 5 | Display, Camera | HUD rendering |
+| DAWN | 3 | TTS, LLM | Voice recognition |


### PR DESCRIPTION
## Summary
- Add Claude LLM integration resources
- Complete README.md rewrite with S.C.O.P.E. branding
- Add CLAUDE.md for LLM integration guidance

## Changes

### New Files
- `CLAUDE.md` - LLM integration guide for S.C.O.P.E.
- `claude/README.md` - Claude usage guide
- `claude/prompts/issue-summary.md` - Example prompt
- `.gitignore` - Standard ignores (includes `docs/claude/scratch/`)

### Modified Files
- `README.md` - Complete rewrite with:
  - S.C.O.P.E. branding
  - Three-tier documentation architecture diagram
  - Component repository overview
  - Hardware paths and feature matrix
  - Contributing guidelines

## Documentation Architecture
```
Portal:       The-OASIS-Project.github.io (user-facing)
Coordination: S.C.O.P.E. (developer guides)
Components:   MIRAGE, DAWN, etc. (code docs)
```

## Test plan
- [ ] README renders correctly on GitHub
- [ ] CLAUDE.md provides useful context for LLM assistance
- [ ] Links in documentation are valid

Closes #2

🤖 Generated with [Claude Code](https://claude.ai/code)