### PR TITLE
feat(templates): add O.A.S.I.S. foundation templates

### DIFF
--- a/templates/oasis-foundation/CLAUDE-template.md
+++ b/templates/oasis-foundation/CLAUDE-template.md
@@ -1,0 +1,92 @@
+# CLAUDE.md - LLM Integration Guide for {COMPONENT_NAME}
+
+## Project Overview
+
+**{COMPONENT_NAME}** is {brief description} within the O.A.S.I.S. (Open-source Assistive System for Integrated Services) ecosystem.
+
+## Key Files
+
+| File/Directory | Purpose |
+|----------------|---------|
+| `src/` | Main source code |
+| `include/` | Header files (if C/C++) |
+| `tests/` | Test files |
+| `Dockerfile.dev` | Development container |
+| `Dockerfile.{platform}` | Platform-specific containers |
+
+## Architecture
+
+{Brief architecture description}
+
+### MQTT Integration
+
+This component communicates with other O.A.S.I.S. components via MQTT:
+
+**Topics Published:**
+- `oasis/{component}/status` - Component status updates
+- `oasis/{component}/{specific_topic}` - {Description}
+
+**Topics Subscribed:**
+- `oasis/{component}/command` - Incoming commands
+- `oasis/{other_component}/{topic}` - {Description}
+
+## Development
+
+### Build Commands
+
+```bash
+# {Primary build command}
+{command}
+
+# Run tests
+{test_command}
+
+# Run linter
+{lint_command}
+```
+
+### Docker Development
+
+```bash
+# Build development image
+docker build -f Dockerfile.dev -t {component}-dev .
+
+# Run with mock hardware
+docker run -it {component}-dev
+
+# Run with volume mount for live development
+docker run -it -v $(pwd):/app {component}-dev
+```
+
+## Code Style
+
+- **Language**: {Language}
+- **Style Guide**: {Style guide reference}
+- **Linter**: {Linter name and config}
+
+## Common Tasks
+
+### Adding a New Feature
+
+1. {Step 1}
+2. {Step 2}
+3. Update MQTT topics if needed
+4. Add tests
+5. Update documentation
+
+### Debugging
+
+{Debugging tips specific to this component}
+
+## Hardware Abstraction
+
+This component uses a hardware abstraction layer:
+
+- **Mock mode**: `HARDWARE_MODE=mock` - Simulated hardware for development
+- **Real mode**: `HARDWARE_MODE=real` - Actual hardware (platform-specific)
+
+## Related Documentation
+
+- [S.C.O.P.E. Coordination](https://github.com/malcolmhoward/the-oasis-project-meta-repo) - Project-wide coordination
+- [Feature Matrix](https://github.com/malcolmhoward/the-oasis-project-meta-repo/blob/main/coordination/skill-tree/FEATURE_MATRIX.md) - Platform compatibility
+- [Docker Architecture](https://github.com/malcolmhoward/the-oasis-project-meta-repo/blob/main/templates/docker/DOCKER_README.md) - Docker patterns

--- a/templates/oasis-foundation/CONTRIBUTING-template.md
+++ b/templates/oasis-foundation/CONTRIBUTING-template.md
@@ -1,0 +1,119 @@
+# Contributing to {COMPONENT_NAME}
+
+Thank you for your interest in contributing to {COMPONENT_NAME} and the O.A.S.I.S. ecosystem!
+
+## Getting Started
+
+1. **Fork** the repository to your GitHub account
+2. **Clone** your fork locally
+3. **Set up** the development environment (see [GETTING_STARTED.md](GETTING_STARTED.md))
+4. **Create a branch** for your changes
+
+## Development Workflow
+
+### Branch Naming
+
+Use descriptive branch names with prefixes:
+
+- `feat/description` - New features
+- `fix/description` - Bug fixes
+- `docs/description` - Documentation updates
+- `refactor/description` - Code refactoring
+- `test/description` - Test additions or fixes
+
+### Commit Messages
+
+Follow [Conventional Commits](https://www.conventionalcommits.org/):
+
+```
+type(scope): brief description
+
+Longer description if needed.
+
+Closes #123
+```
+
+Types: `feat`, `fix`, `docs`, `style`, `refactor`, `test`, `chore`
+
+### Pull Request Process
+
+1. **Update documentation** if your changes affect usage
+2. **Add tests** for new functionality
+3. **Run all tests** locally before submitting
+4. **Create PR** with clear description of changes
+5. **Link related issues** using "Closes #123" or "Fixes #123"
+6. **Request review** from maintainers
+
+## Code Standards
+
+### {Language} Style
+
+{Language-specific style guidelines}
+
+### Testing
+
+- Write tests for all new features
+- Maintain or improve code coverage
+- Test on multiple platforms if possible
+
+### Documentation
+
+- Update README.md for user-facing changes
+- Update CLAUDE.md for development-related changes
+- Add inline comments for complex logic
+
+## Types of Contributions
+
+### Bug Reports
+
+- Use the issue template
+- Include hardware platform details
+- Provide steps to reproduce
+- Include relevant logs
+
+### Feature Requests
+
+- Check existing issues first
+- Describe the use case
+- Consider impact on other components
+
+### Code Contributions
+
+- Start with smaller issues labeled `good first issue`
+- Discuss larger changes in an issue first
+- Follow existing patterns in the codebase
+
+### Documentation
+
+- Fix typos and clarify confusing sections
+- Add examples and tutorials
+- Improve setup instructions
+
+### Hardware Testing
+
+- Test on different platforms (Pi, Jetson)
+- Report compatibility findings
+- Share hardware configurations that work well
+
+## Communication
+
+- **GitHub Issues** - Bug reports and feature requests
+- **Pull Requests** - Code discussions
+- **O.A.S.I.S. Discord** - Community chat (if available)
+
+## Code of Conduct
+
+Be respectful and inclusive. We're all here to build something awesome together.
+
+## Recognition
+
+Contributors will be acknowledged in release notes and the project README.
+
+## Questions?
+
+If you're unsure about anything, open an issue and ask! We're happy to help.
+
+## Related Resources
+
+- [S.C.O.P.E. Coordination](https://github.com/malcolmhoward/the-oasis-project-meta-repo) - Project-wide guidelines
+- [Docker Development](https://github.com/malcolmhoward/the-oasis-project-meta-repo/blob/main/templates/docker/DOCKER_README.md) - Container patterns

--- a/templates/oasis-foundation/README-template.md
+++ b/templates/oasis-foundation/README-template.md
@@ -1,0 +1,98 @@
+# {COMPONENT_NAME}
+
+{Brief one-line description of the component}
+
+Part of the [O.A.S.I.S. Project](https://github.com/The-OASIS-Project) - Open-source Assistive System for Integrated Services.
+
+## Overview
+
+{2-3 paragraph description of what this component does, its role in the O.A.S.I.S. ecosystem, and key features}
+
+## Features
+
+- {Feature 1}
+- {Feature 2}
+- {Feature 3}
+
+## Hardware Requirements
+
+| Platform | Support Level | Notes |
+|----------|---------------|-------|
+| Raspberry Pi 4/5 | {Full/Limited/None} | {Notes} |
+| Jetson Orin Nano | {Full/Limited/None} | {Notes} |
+| Jetson Xavier NX | {Full/Limited/None} | {Notes} |
+
+See [S.C.O.P.E. Feature Matrix](https://github.com/malcolmhoward/the-oasis-project-meta-repo/blob/main/coordination/skill-tree/FEATURE_MATRIX.md) for detailed compatibility.
+
+## Quick Start
+
+### Prerequisites
+
+- {Prerequisite 1}
+- {Prerequisite 2}
+
+### Installation
+
+```bash
+# Clone the repository
+git clone https://github.com/The-OASIS-Project/{component_name}.git
+cd {component_name}
+
+# {Installation steps}
+```
+
+### Docker Development
+
+```bash
+# Build development image
+docker build -f Dockerfile.dev -t {component_name}-dev .
+
+# Run in development mode
+docker run -it {component_name}-dev
+```
+
+See [GETTING_STARTED.md](GETTING_STARTED.md) for detailed setup instructions.
+
+## Architecture
+
+{Brief description of component architecture}
+
+```
+{ASCII diagram or component structure}
+```
+
+## MQTT Topics
+
+This component uses the following MQTT topics:
+
+| Topic | Direction | Description |
+|-------|-----------|-------------|
+| `oasis/{component}/status` | Publish | Status updates |
+| `oasis/{component}/command` | Subscribe | Incoming commands |
+
+## Contributing
+
+We welcome contributions! Please see [CONTRIBUTING.md](CONTRIBUTING.md) for guidelines.
+
+## Documentation
+
+- [S.C.O.P.E.](https://github.com/malcolmhoward/the-oasis-project-meta-repo) - Project coordination and hardware guides
+- [O.A.S.I.S. Docs](https://the-oasis-project.github.io/) - Public documentation portal
+
+## Related Components
+
+- [MIRAGE](https://github.com/The-OASIS-Project/mirage) - HUD Display
+- [DAWN](https://github.com/The-OASIS-Project/dawn) - AI Assistant
+- [SPARK](https://github.com/The-OASIS-Project/spark) - Hand/Gauntlet
+- [AURA](https://github.com/The-OASIS-Project/aura) - Helmet Sensors
+- [BEACON](https://github.com/The-OASIS-Project/beacon) - CAD Models
+- [GENESIS](https://github.com/The-OASIS-Project/genesis) - Python Utilities
+
+## License
+
+This project is licensed under the GNU General Public License v3.0 - see the [LICENSE](LICENSE) file for details.
+
+## Acknowledgments
+
+- [The O.A.S.I.S. Project](https://github.com/The-OASIS-Project) and Kris Kersey
+- All contributors to the O.A.S.I.S. ecosystem


### PR DESCRIPTION
## Summary

Add standardized templates for O.A.S.I.S. component repositories:
- `README-template.md` - Project overview structure
- `CLAUDE-template.md` - LLM integration guidance
- `CONTRIBUTING-template.md` - Contribution guidelines

## Purpose

These templates ensure consistent documentation across all O.A.S.I.S. repos (MIRAGE, DAWN, SPARK, AURA, BEACON, GENESIS) and make it easy to onboard new contributors.

## Test plan

- [ ] Verify templates follow WHAT/WHY/HOW educational pattern
- [ ] Confirm placeholders are clearly marked
- [ ] Ensure templates follow WHAT/WHY/HOW educational pattern

## PR Chain
This PR is part of a chain:
- PR #24: Initialize submodules (merged into → this PR's base)
- PR #25: Claude LLM integration
- PR #26: Directory structure
- **This PR (#27)**: Foundation templates

Closes #6

🤖 Generated with [Claude Code](https://claude.com/claude-code)