### PR TITLE
Create documentation aggregation pipeline

### DIFF
--- a/coordination/standards/component-documentation.md
+++ b/coordination/standards/component-documentation.md
@@ -2,6 +2,10 @@
 
 This document defines the baseline documentation structure for O.A.S.I.S. component repositories to ensure consistency and quality across the ecosystem.
 
+## Scope
+
+This standard covers **technical documentation** (`docs/guide.md` and related files). Governance files (`LICENSE`, `CONTRIBUTING.md`, `CLAUDE.md`, `README.md`) are covered separately by S.C.O.P.E. issue #22 (Foundation file standardization).
+
 ## Documentation Location
 
 All component documentation lives in the `docs/` folder at the repository root:
@@ -22,18 +26,35 @@ Every component MUST have a `docs/guide.md` file that serves as the primary docu
 
 ### Required Sections
 
-| Section | Purpose |
-|---------|---------|
-| **Title & Logo** | Component name, acronym expansion, logo from public assets |
-| **Overview** | What the component does and its role in O.A.S.I.S. |
-| **Hardware** | Required hardware with links to purchase/specs |
-| **Software Dependencies** | Libraries, frameworks, tools needed |
-| **Installation** | Step-by-step setup instructions |
-| **Configuration** | How to configure the component |
-| **Usage** | How to use the component |
-| **Communication** | Protocol reference (link to mqtt-protocols.md) |
-| **Troubleshooting** | Common issues and solutions |
-| **Related Components** | Links to components this one interacts with |
+Not all sections apply to every component. Sections marked as conditional may be omitted with a brief note explaining why (e.g., "GENESIS has no hardware requirements").
+
+| Section | Purpose | Applicability |
+|---------|---------|---------------|
+| **Title & Logo** | Component name, acronym expansion, logo from public assets | All components |
+| **Overview** | What the component does and its role in O.A.S.I.S. | All components |
+| **Hardware** | Required hardware with links to purchase/specs | Hardware-dependent components (MIRAGE, DAWN, AURA, SPARK, BEACON) |
+| **Software Dependencies** | Libraries, frameworks, tools needed | All components |
+| **Installation** | Step-by-step setup instructions | All components |
+| **Configuration** | How to configure the component | Components with configurable behavior |
+| **Usage** | How to use the component | All components |
+| **Communication** | MQTT topics and protocol reference | Components that communicate via MQTT (MIRAGE, DAWN, AURA, SPARK) |
+| **Troubleshooting** | Common issues and solutions | All components |
+| **Related Components** | Links to components this one interacts with | All components |
+
+#### Applicability by Component
+
+| Section | MIRAGE | DAWN | AURA | SPARK | BEACON | GENESIS |
+|---------|:------:|:----:|:----:|:-----:|:------:|:-------:|
+| Title & Logo | Yes | Yes | Yes | Yes | Yes | Yes |
+| Overview | Yes | Yes | Yes | Yes | Yes | Yes |
+| Hardware | Yes | Yes | Yes | Yes | Yes | No |
+| Software Dependencies | Yes | Yes | Yes | Yes | Yes | Yes |
+| Installation | Yes | Yes | Yes | Yes | Yes | Yes |
+| Configuration | Yes | Yes | Yes | Yes | No | Yes |
+| Usage | Yes | Yes | Yes | Yes | Yes | Yes |
+| Communication | Yes | Yes | Yes | Yes | No | No |
+| Troubleshooting | Yes | Yes | Yes | Yes | Yes | Yes |
+| Related Components | Yes | Yes | Yes | Yes | Yes | Yes |
 
 ### Section Templates
 
@@ -71,6 +92,9 @@ Every component MUST have a `docs/guide.md` file that serves as the primary docu
 ```
 
 #### Communication Section
+
+Only applicable to components that communicate via MQTT (MIRAGE, DAWN, AURA, SPARK). BEACON (CAD models) and GENESIS (utilities) do not use MQTT and should omit this section.
+
 ```markdown
 ## Communication
 
@@ -132,20 +156,30 @@ To add new documentation to the aggregation, update the `COMPONENT_DOCS` mapping
 
 Before committing documentation changes:
 
-- [ ] All required sections present
+- [ ] All required sections present (per applicability matrix above)
+- [ ] Conditional sections either filled or explicitly noted as N/A
 - [ ] Asset URLs use absolute paths to oasisproject.net
 - [ ] Hardware links are valid
 - [ ] Code examples are tested
-- [ ] No placeholder text remains
+- [ ] No placeholder text remains (no `<Component>`, `<Description>`, `<url>`, etc. from templates)
 - [ ] Cross-references to other components are accurate
 - [ ] Spelling and grammar checked
 
-## Examples
+## Current State
 
-**Comprehensive documentation:**
-- [MIRAGE guide.md](../../repos/mirage/docs/guide.md) - Full-featured example
-- [DAWN guide.md](../../repos/dawn/docs/guide.md) - Includes local LLM setup
+Status of component documentation relative to this standard:
 
-**Minimal documentation (needs enhancement):**
-- [AURA guide.md](../../repos/aura/docs/guide.md)
-- [SPARK guide.md](../../repos/spark/docs/guide.md)
+| Component | guide.md | Content Level | Key Gaps |
+|-----------|:--------:|---------------|----------|
+| MIRAGE | Yes | Comprehensive | Missing: Overview, Communication, Troubleshooting, Related Components |
+| DAWN | Yes | Comprehensive | Needs review against standard |
+| AURA | Yes | Minimal | Missing: Overview, full Installation, Configuration, Usage, Communication, Troubleshooting, Related |
+| SPARK | Yes | Needs review | Needs review against standard |
+| BEACON | **No** | parts-catalog.md only | Missing guide.md entirely |
+| GENESIS | **No docs/** | None | Everything |
+
+**Examples of existing documentation:**
+- [MIRAGE guide.md](../../repos/mirage/docs/guide.md) - Most complete; good reference for Hardware and Configuration sections
+- [DAWN guide.md](../../repos/dawn/docs/guide.md) - Includes additional topic file (local-llm.md)
+- [AURA guide.md](../../repos/aura/docs/guide.md) - Good Title/Logo and Hardware sections; needs remaining sections
+- [BEACON parts-catalog.md](../../repos/beacon/docs/parts-catalog.md) - Useful content, needs guide.md wrapper

--- a/coordination/standards/ecosystem-documentation.md
+++ b/coordination/standards/ecosystem-documentation.md
@@ -1,6 +1,6 @@
-# Component Documentation Standard
+# Ecosystem Documentation Standard
 
-This document defines the baseline documentation structure for O.A.S.I.S. component repositories to ensure consistency and quality across the ecosystem.
+This document defines the baseline documentation structure for all repositories in the O.A.S.I.S. ecosystem, including components, coordination infrastructure, and the documentation portal.
 
 ## Scope
 
@@ -8,7 +8,7 @@ This standard covers **technical documentation** (`docs/guide.md` and related fi
 
 ## Documentation Location
 
-All component documentation lives in the `docs/` folder at the repository root:
+All repository documentation lives in the `docs/` folder at the repository root:
 
 ```
 <component>/
@@ -22,39 +22,39 @@ All component documentation lives in the `docs/` folder at the repository root:
 
 ## Required File: `docs/guide.md`
 
-Every component MUST have a `docs/guide.md` file that serves as the primary documentation. This file is aggregated to GitHub Pages.
+Every repository MUST have a `docs/guide.md` file that serves as the primary documentation. For component repositories, this file is aggregated to GitHub Pages.
 
 ### Required Sections
 
-Not all sections apply to every component. Sections marked as conditional may be omitted with a brief note explaining why (e.g., "GENESIS has no hardware requirements").
+Not all sections apply to every repository. Sections marked as conditional may be omitted with a brief note explaining why (e.g., "GENESIS has no hardware requirements").
 
 | Section | Purpose | Applicability |
 |---------|---------|---------------|
-| **Title & Logo** | Component name, acronym expansion, logo from public assets | All components |
-| **Overview** | What the component does and its role in O.A.S.I.S. | All components |
+| **Title & Logo** | Repository name, acronym expansion, logo from public assets | All repositories |
+| **Overview** | What the repository provides and its role in O.A.S.I.S. | All repositories |
 | **Hardware** | Required hardware with links to purchase/specs | Hardware-dependent components (MIRAGE, DAWN, AURA, SPARK, BEACON) |
-| **Software Dependencies** | Libraries, frameworks, tools needed | All components |
-| **Installation** | Step-by-step setup instructions | All components |
-| **Configuration** | How to configure the component | Components with configurable behavior |
-| **Usage** | How to use the component | All components |
+| **Software Dependencies** | Libraries, frameworks, tools needed | All repositories |
+| **Installation** | Step-by-step setup instructions | All repositories |
+| **Configuration** | How to configure the component/system | Repositories with configurable behavior |
+| **Usage** | How to use the component/system | All repositories |
 | **Communication** | MQTT topics and protocol reference | Components that communicate via MQTT (MIRAGE, DAWN, AURA, SPARK) |
-| **Troubleshooting** | Common issues and solutions | All components |
-| **Related Components** | Links to components this one interacts with | All components |
+| **Troubleshooting** | Common issues and solutions | All repositories |
+| **Related Components** | Links to other repositories this one interacts with | All repositories |
 
-#### Applicability by Component
+#### Applicability by Repository
 
-| Section | MIRAGE | DAWN | AURA | SPARK | BEACON | GENESIS |
-|---------|:------:|:----:|:----:|:-----:|:------:|:-------:|
-| Title & Logo | Yes | Yes | Yes | Yes | Yes | Yes |
-| Overview | Yes | Yes | Yes | Yes | Yes | Yes |
-| Hardware | Yes | Yes | Yes | Yes | Yes | No |
-| Software Dependencies | Yes | Yes | Yes | Yes | Yes | Yes |
-| Installation | Yes | Yes | Yes | Yes | Yes | Yes |
-| Configuration | Yes | Yes | Yes | Yes | No | Yes |
-| Usage | Yes | Yes | Yes | Yes | Yes | Yes |
-| Communication | Yes | Yes | Yes | Yes | No | No |
-| Troubleshooting | Yes | Yes | Yes | Yes | Yes | Yes |
-| Related Components | Yes | Yes | Yes | Yes | Yes | Yes |
+| Section | MIRAGE | DAWN | AURA | SPARK | BEACON | GENESIS | GitHub Pages | S.C.O.P.E. |
+|---------|:------:|:----:|:----:|:-----:|:------:|:-------:|:------------:|:----------:|
+| Title & Logo | Yes | Yes | Yes | Yes | Yes | Yes | Yes | Yes |
+| Overview | Yes | Yes | Yes | Yes | Yes | Yes | Yes | Yes |
+| Hardware | Yes | Yes | Yes | Yes | Yes | No | No | No |
+| Software Dependencies | Yes | Yes | Yes | Yes | Yes | Yes | Yes | Yes |
+| Installation | Yes | Yes | Yes | Yes | Yes | Yes | Yes | Yes |
+| Configuration | Yes | Yes | Yes | Yes | No | Yes | Yes | Yes |
+| Usage | Yes | Yes | Yes | Yes | Yes | Yes | Yes | Yes |
+| Communication | Yes | Yes | Yes | Yes | No | No | No | No |
+| Troubleshooting | Yes | Yes | Yes | Yes | Yes | Yes | Yes | Yes |
+| Related Components | Yes | Yes | Yes | Yes | Yes | Yes | Yes | Yes |
 
 ### Section Templates
 
@@ -93,7 +93,7 @@ Not all sections apply to every component. Sections marked as conditional may be
 
 #### Communication Section
 
-Only applicable to components that communicate via MQTT (MIRAGE, DAWN, AURA, SPARK). BEACON (CAD models) and GENESIS (utilities) do not use MQTT and should omit this section.
+Only applicable to components that communicate via MQTT (MIRAGE, DAWN, AURA, SPARK). BEACON (CAD models), GENESIS (utilities), GitHub Pages (documentation portal), and S.C.O.P.E. (coordination) do not use MQTT and should omit this section.
 
 ```markdown
 ## Communication
@@ -129,16 +129,18 @@ This component communicates via MQTT. See the [O.A.S.I.S. Communication Protocol
 
 See [ADR-0004: Documentation Infrastructure](../decisions/adr/0004-documentation-infrastructure.md) for rationale.
 
-## Component-Specific Documentation
+## Repository-Specific Documentation
 
-Beyond `guide.md`, components may have additional documentation:
+Beyond `guide.md`, repositories may have additional documentation:
 
-| Component Type | Additional Docs |
-|----------------|-----------------|
+| Repository Type | Additional Docs |
+|-----------------|-----------------|
 | Firmware (AURA, SPARK) | `flashing.md`, `calibration.md` |
 | Software (MIRAGE, DAWN) | `configuration.md`, `api.md` |
 | Hardware (BEACON) | `parts-catalog.md`, `print-settings.md` |
 | Utilities (GENESIS) | `scripts.md`, `tools.md` |
+| Portal (GitHub Pages) | `aggregation.md`, `deployment.md` |
+| Coordination (S.C.O.P.E.) | `submodules.md`, `branching.md` |
 
 ## Aggregation Mapping
 
@@ -167,16 +169,18 @@ Before committing documentation changes:
 
 ## Current State
 
-Status of component documentation relative to this standard:
+Status of repository documentation relative to this standard:
 
-| Component | guide.md | Content Level | Key Gaps |
-|-----------|:--------:|---------------|----------|
+| Repository | guide.md | Content Level | Key Gaps |
+|------------|:--------:|---------------|----------|
 | MIRAGE | Yes | Comprehensive | Missing: Overview, Communication, Troubleshooting, Related Components |
 | DAWN | Yes | Comprehensive | Needs review against standard |
 | AURA | Yes | Minimal | Missing: Overview, full Installation, Configuration, Usage, Communication, Troubleshooting, Related |
 | SPARK | Yes | Needs review | Needs review against standard |
 | BEACON | **No** | parts-catalog.md only | Missing guide.md entirely |
 | GENESIS | **No docs/** | None | Everything |
+| GitHub Pages | **No** | Has README and CLAUDE.md but no guide.md | Missing guide.md; Configuration and Usage content exists in CLAUDE.md but not in standard format |
+| S.C.O.P.E. | **No** | Has extensive README.md and CLAUDE.md | Missing guide.md; coordination docs exist but not in standard format |
 
 **Examples of existing documentation:**
 - [MIRAGE guide.md](../../repos/mirage/docs/guide.md) - Most complete; good reference for Hardware and Configuration sections

--- a/docs/guide.md
+++ b/docs/guide.md
@@ -1,0 +1,139 @@
+# S.C.O.P.E. - [Name Pending] (Ecosystem Coordination)
+
+## Overview
+
+S.C.O.P.E. (name and acronym pending stakeholder selection) is the meta-repository that coordinates the O.A.S.I.S. wearable computing ecosystem. It tracks all component repositories as git submodules, provides shared governance tooling, and maintains ecosystem-level documentation, standards, and decision records.
+
+S.C.O.P.E. serves three primary functions:
+- **Coordination**: Tracks component repo states via submodule references, ensuring reproducible ecosystem snapshots
+- **Standards**: Maintains ecosystem-wide documentation standards, communication protocols, and architecture decision records (ADRs)
+- **Tooling**: Provides shared infrastructure including PFT (Project Foundation Template) for governance file generation
+
+## Software Dependencies
+
+| Tool | Purpose |
+|------|---------|
+| Git (with submodule support) | Repository coordination and version tracking |
+| Python 3.7+ | PFT governance template generation |
+| GitHub CLI (`gh`) | Issue management and cross-repo coordination |
+
+## Installation
+
+### Prerequisites
+
+- Git 2.13+ (for submodule support)
+- GitHub account with access to component repositories
+
+### Setup
+
+```bash
+# Clone with all submodules
+git clone --recurse-submodules https://github.com/malcolmhoward/the-oasis-project-meta-repo.git
+cd the-oasis-project-meta-repo
+
+# Or initialize submodules after cloning
+git submodule update --init --recursive
+```
+
+### Submodule Structure
+
+```
+the-oasis-project-meta-repo/
+├── repos/
+│   ├── mirage/                    # M.I.R.A.G.E. HUD system
+│   ├── dawn/                      # D.A.W.N. AI assistant
+│   ├── aura/                      # A.U.R.A. helmet firmware
+│   ├── spark/                     # S.P.A.R.K. gauntlet firmware
+│   ├── beacon/                    # B.E.A.C.O.N. CAD models
+│   ├── genesis/                   # G.E.N.E.S.I.S. Python utilities
+│   ├── github-pages/             # Documentation portal
+│   └── project-foundation-template/  # PFT governance tooling
+├── coordination/
+│   ├── standards/                 # Ecosystem-wide standards
+│   ├── protocols/                 # Communication protocols (MQTT)
+│   ├── hardware-guides/           # Hardware selection guides
+│   └── decisions/adr/             # Architecture Decision Records
+├── docs/
+│   └── guide.md                   # This file
+├── templates/                     # Shared templates
+└── scratch/                       # Working files (gitignored)
+```
+
+## Configuration
+
+### Submodule Management
+
+Each submodule tracks a specific commit of its component repository. To update a submodule to its latest commit:
+
+```bash
+cd repos/<component>
+git checkout main && git pull
+cd ../..
+git add repos/<component>
+git commit -m "chore: Update <component> submodule reference"
+```
+
+To update all submodules:
+
+```bash
+git submodule update --remote
+```
+
+### Branch Strategy
+
+Feature branches in S.C.O.P.E. follow the convention:
+```
+feat/<issue#>-<description>          # Meta-repo level work
+feat/<component>/<issue#>-<description>  # Component-level work
+```
+
+## Usage
+
+### Ecosystem Coordination
+
+S.C.O.P.E. submodule pointers capture coordinated states across the ecosystem. A single S.C.O.P.E. commit can represent a known-good combination of all component versions.
+
+### Governance Generation (PFT)
+
+Generate foundation files for new or existing components:
+
+```bash
+cd repos/project-foundation-template
+python generate_foundation.py --preset minimal --project-name "ComponentName" --author-name "The O.A.S.I.S. Project"
+```
+
+### Issue Tracking
+
+S.C.O.P.E. uses a two-tier issue tracking model:
+
+- **Meta-issues** in the meta-repo track ecosystem-wide initiatives
+- **Repo-level issues** in each component repo track implementation work
+- Meta-issues reference repo-level issues for cross-repo visibility
+
+When a meta-issue affects S.C.O.P.E. itself (not just its coordination role), S.C.O.P.E. should have its own repo-level issue, just as component repos do. See ADR-0002 §4.5.
+
+### Standards and ADRs
+
+Ecosystem standards live in `coordination/standards/`. Architecture decisions are recorded in `coordination/decisions/adr/`. These apply to all repositories in the ecosystem, including S.C.O.P.E. itself.
+
+## Troubleshooting
+
+| Issue | Possible Cause | Solution |
+|-------|---------------|----------|
+| Submodule checkout empty | Submodules not initialized | Run `git submodule update --init --recursive` |
+| Submodule on detached HEAD | Normal after `submodule update` | `cd repos/<component> && git checkout main` to work on a branch |
+| Submodule conflicts during merge | Different submodule commits on branches | Resolve by choosing the correct commit reference |
+| PFT generation fails | Python not installed or wrong version | Verify Python 3.7+ is available |
+| `gh` commands fail | GitHub CLI not authenticated | Run `gh auth login` |
+| Stale submodule references | Component repos have advanced | Run `git submodule update --remote` to sync |
+
+## Related Components
+
+- [M.I.R.A.G.E.](https://www.oasisproject.net/components/mirage/) - HUD system (submodule at `repos/mirage`)
+- [D.A.W.N.](https://www.oasisproject.net/components/dawn/) - AI assistant (submodule at `repos/dawn`)
+- [A.U.R.A.](https://www.oasisproject.net/components/aura/) - Helmet firmware (submodule at `repos/aura`)
+- [S.P.A.R.K.](https://www.oasisproject.net/components/spark/) - Gauntlet firmware (submodule at `repos/spark`)
+- [B.E.A.C.O.N.](https://www.oasisproject.net/components/beacon/) - CAD models (submodule at `repos/beacon`)
+- [G.E.N.E.S.I.S.](https://www.oasisproject.net/components/genesis/) - Python utilities (submodule at `repos/genesis`)
+- [Documentation Portal](https://www.oasisproject.net/) - Public site (submodule at `repos/github-pages`)
+- [PFT](https://github.com/malcolmhoward/project-foundation-template) - Governance template generator (submodule at `repos/project-foundation-template`)


### PR DESCRIPTION
## Summary
- Create S.C.O.P.E. docs/guide.md per ecosystem documentation standard
- Create ecosystem documentation standard (coordination/standards/)
- Add MQTT communication protocols documentation
- Establish documentation aggregation pipeline across all 8 repos

Component-level docs-gap-fill PRs are linked from meta-issue #29.

Tracked by: #29

## Test plan
- [ ] Verify docs/guide.md has all required sections
- [ ] Verify ecosystem documentation standard covers all 8 repos
- [ ] Verify all component repos have docs/guide.md (tracked via component PRs)

🤖 Generated with [Claude Code](https://claude.com/claude-code)