### PR TITLE
Add O.A.S.I.S. ecosystem simulation demo

### DIFF
--- a/demos/ecosystem-mock/README.md
+++ b/demos/ecosystem-mock/README.md
@@ -1,0 +1,131 @@
+# O.A.S.I.S. Ecosystem Simulation Demo
+
+Run the entire O.A.S.I.S. ecosystem on a single machine — no specialized hardware, GPU, or API keys required. All components are simulated by the [E.C.H.O.](https://github.com/malcolmhoward/the-oasis-project-simulation-repo) simulation framework.
+
+## What This Demonstrates
+
+Multiple O.A.S.I.S. components coexisting on a shared MQTT network, each running as an OCP (OASIS Communications Protocol) E4 software peer:
+
+```
+┌──────────────────────────────────────────────────────────────────────┐
+│                        Docker Compose                                │
+│                                                                      │
+│  ┌──────────────┐  ┌──────────────────────────────────────────────┐  │
+│  │ mqtt-broker   │  │ mock-ecosystem                              │  │
+│  │ (Mosquitto)   │  │                                              │  │
+│  │ :1883         │  │  OCP peers:                                  │  │
+│  │               │  │    echo-aura-simulation  (sensors)           │  │
+│  │               │  │    echo-stat-simulation  (system metrics)    │  │
+│  │               │  │    echo-scope-simulation (coordination)      │  │
+│  │               │  │                                              │  │
+│  │               │  │  Sensor publisher:                           │  │
+│  │               │  │    aura topic (motion/GPS/enviro) at ~1Hz    │  │
+│  │               │  │    stat topic (CPU/memory/battery) at ~1Hz   │  │
+│  │               │  │                                              │  │
+│  │               │  │  Service mocks:                              │  │
+│  │               │  │    HA REST API :8123                         │  │
+│  │               │  │    LLM API :8080                             │  │
+│  └───────┬───────┘  └────────────────────┬───────────────────────┘  │
+│          │            MQTT + HTTP         │                          │
+│          └───────────────────────────────┘                          │
+│                                                                      │
+│  ┌─ Optional (uncomment in docker-compose.demo.yaml) ──────────┐    │
+│  │  dawn    — D.A.W.N. WebUI :3000 (connects to mock services) │    │
+│  │  mirage  — M.I.R.A.G.E. HUD (displays simulated sensors)    │    │
+│  └──────────────────────────────────────────────────────────────┘    │
+└──────────────────────────────────────────────────────────────────────┘
+```
+
+## Requirements
+
+- Docker and Docker Compose
+- ~500 MB disk (Python-based mock services)
+- No GPU, no API keys, no external services
+
+## Quick Start
+
+```bash
+# From the meta-repo root
+docker compose -f demos/ecosystem-mock/docker-compose.demo.yaml up --build
+```
+
+## What You'll See
+
+Once running, the mock ecosystem publishes data on the MQTT network at ~1Hz:
+
+### MQTT Topics (subscribe to observe)
+
+```bash
+# In a separate terminal — subscribe to all topics
+docker exec -it <mqtt-broker-container> mosquitto_sub -t '#' -v
+```
+
+| Topic | Publisher | Data |
+|-------|-----------|------|
+| `aura` | echo-aura-simulation | Motion (heading/pitch/roll), GPS (lat/lon/satellites), Environmental (temp/humidity/CO2) |
+| `stat` | echo-stat-simulation | SystemMetrics (CPU/memory/temp), BatteryStatus (voltage/current/percentage) |
+| `aura/status` | echo-aura-simulation | OCP online status (retained, heartbeat every 30s) |
+| `stat/status` | echo-stat-simulation | OCP online status (retained, heartbeat every 30s) |
+| `scope/status` | echo-scope-simulation | OCP online status (retained, heartbeat every 30s) |
+| `echo/discovery/simulates` | All peers | Discovery messages identifying simulated components |
+
+### Service Endpoints
+
+| Service | URL | Description |
+|---------|-----|-------------|
+| Home Assistant API | http://localhost:8123/api/states | Entity states (kitchen lights, bedroom lights, thermostat) |
+| LLM API | http://localhost:8080/v1/models | Model listing |
+| LLM Chat | http://localhost:8080/v1/chat/completions | OpenAI-compatible chat (keyword → tool call) |
+
+## Adding D.A.W.N. to the Ecosystem
+
+Uncomment the `dawn` service in `docker-compose.demo.yaml`, or run the D.A.W.N. demo separately and point it at this network's MQTT broker:
+
+```bash
+# Option 1: Uncomment in docker-compose.demo.yaml and rebuild
+docker compose -f demos/ecosystem-mock/docker-compose.demo.yaml up --build
+
+# Option 2: Run D.A.W.N. demo on the same Docker network
+docker compose -f demos/ecosystem-mock/docker-compose.demo.yaml up -d
+docker compose -f repos/dawn/demos/full-mock/docker-compose.demo.yaml \
+  --env-file /dev/null up --build
+```
+
+Then open **http://localhost:3000** for D.A.W.N.'s WebUI. Type "turn on the kitchen lights" to see the full pipeline:
+user input → LLM mock → tool call → HA mock → entity state change.
+
+## Adding M.I.R.A.G.E. to the Ecosystem
+
+M.I.R.A.G.E. can connect to the same MQTT broker to display simulated sensor data on its HUD:
+
+```bash
+# Build M.I.R.A.G.E. and point it at the ecosystem broker
+cd repos/mirage && mkdir -p build && cd build && cmake .. && make -j$(nproc)
+./mirage --broker <host-ip> -b  # black background mode for UI testing
+```
+
+M.I.R.A.G.E. subscribes to `aura` and `stat` topics and displays heading, pitch, roll, GPS coordinates, environmental data, and system metrics — all from simulated data.
+
+## OCP Component Discovery
+
+Each simulated peer publishes to `echo/discovery/simulates` (retained) so other components can distinguish simulated peers from physical hardware:
+
+```json
+{
+  "peer_id": "echo-aura-simulation",
+  "component": "aura",
+  "embodiment": "software",
+  "capabilities": ["motion", "gps", "environmental"],
+  "timestamp": 1711148400
+}
+```
+
+This aligns with ADR-0003 Amendment 4 (runtime injection and graceful degradation) — real components can coexist with simulated peers on the same network, and the Provider pattern (future) can swap between them transparently.
+
+## Related
+
+- [E.C.H.O. Simulation Framework](https://github.com/malcolmhoward/the-oasis-project-simulation-repo) — Mock implementations for all three layers
+- [D.A.W.N. Full Mock Demo](https://github.com/malcolmhoward/dawn/tree/feat/dawn/5-simulation-demo/demos/full-mock) — D.A.W.N. with all services mocked
+- [M.I.R.A.G.E. HUD Mock Demo](https://github.com/malcolmhoward/mirage/tree/feat/mirage/5-simulation-demo/demos/hud-mock) — HUD display with simulated sensors
+- [ADR-0003](../../coordination/decisions/adr/0003-simulation-environment-architecture.md) — Simulation environment architecture (Amendments 1-4)
+- [ADR-0007](../../coordination/decisions/adr/0007-component-naming-convention.md) — Component naming convention

--- a/demos/ecosystem-mock/docker-compose.demo.yaml
+++ b/demos/ecosystem-mock/docker-compose.demo.yaml
@@ -1,0 +1,78 @@
+# O.A.S.I.S. Ecosystem Simulation Demo
+#
+# Runs the full O.A.S.I.S. ecosystem with all components simulated:
+#   - Simulated A.U.R.A. sensors (motion, GPS, environmental)
+#   - Simulated S.T.A.T. system metrics (CPU, memory, battery)
+#   - OCP E4 software peers (A.U.R.A., S.T.A.T., S.C.O.P.E.)
+#   - Home Assistant mock (smart home entity control)
+#   - LLM mock (OpenAI-compatible keyword → tool call mapping)
+#   - MQTT broker (shared network for all components)
+#
+# Optionally add D.A.W.N. and/or M.I.R.A.G.E. to the network by
+# running their own demo compose files with the same MQTT broker.
+#
+# Usage:
+#   docker compose -f demos/ecosystem-mock/docker-compose.demo.yaml up --build
+#
+# No GPU, no API keys, no external services required.
+
+services:
+  mqtt-broker:
+    image: eclipse-mosquitto:2
+    volumes:
+      - ./mosquitto.conf:/mosquitto/config/mosquitto.conf:ro
+    ports:
+      - "1883:1883"
+    healthcheck:
+      test: ["CMD-SHELL", "mosquitto_sub -t '$$SYS/broker/uptime' -C 1 -W 3"]
+      interval: 5s
+      timeout: 3s
+      retries: 3
+
+  mock-ecosystem:
+    build:
+      context: .
+      dockerfile: mock_ecosystem/Dockerfile
+    environment:
+      - MQTT_BROKER=mqtt-broker
+      - MQTT_PORT=1883
+      - HA_PORT=8123
+      - LLM_PORT=8080
+      - PUBLISH_INTERVAL=1.0
+    ports:
+      - "8123:8123"
+      - "8080:8080"
+    depends_on:
+      mqtt-broker:
+        condition: service_healthy
+    healthcheck:
+      test: ["CMD-SHELL", "python -c \"import urllib.request; urllib.request.urlopen('http://localhost:8080/v1/models')\""]
+      interval: 5s
+      timeout: 3s
+      retries: 3
+
+  # --- Optional: Add real D.A.W.N. to the simulated ecosystem ---
+  # Uncomment this section if you have built the D.A.W.N. Docker image.
+  # D.A.W.N. connects to the mock services and displays in its WebUI.
+  #
+  # dawn:
+  #   image: dawn:dev
+  #   volumes:
+  #     - ../repos/dawn/demos/full-mock/dawn-simulation.toml:/opt/dawn/dawn.toml:ro
+  #     - ../repos/dawn/demos/full-mock/secrets-simulation.toml:/opt/dawn/secrets.toml:ro
+  #   ports:
+  #     - "3000:3000"
+  #   depends_on:
+  #     mqtt-broker:
+  #       condition: service_healthy
+  #     mock-ecosystem:
+  #       condition: service_healthy
+  #   environment:
+  #     - DAWN_LLM_TYPE=local
+  #     - DAWN_LLM_LOCAL_ENDPOINT=http://mock-ecosystem:8080
+  #     - DAWN_LLM_LOCAL_PROVIDER=generic
+  #     - DAWN_MQTT_BROKER=mqtt-broker
+  #     - DAWN_HOMEASSISTANT_URL=http://mock-ecosystem:8123
+  #     - DAWN_AUDIO_ENABLED=false
+  #     - DAWN_ASR_ENABLED=false
+  #     - DAWN_TTS_ENABLED=false

--- a/demos/ecosystem-mock/mock_ecosystem/Dockerfile
+++ b/demos/ecosystem-mock/mock_ecosystem/Dockerfile
@@ -1,0 +1,15 @@
+# Mock ecosystem container — runs simulated O.A.S.I.S. components
+# from the E.C.H.O. simulation framework.
+
+FROM python:3.12-slim
+
+WORKDIR /opt/mock-ecosystem
+
+# Install simulation framework
+COPY simulation_framework/ /opt/simulation_framework/
+RUN pip install --no-cache-dir -e "/opt/simulation_framework[all]"
+
+# Copy mock ecosystem entrypoint
+COPY mock_ecosystem/ /opt/mock-ecosystem/
+
+CMD ["python", "entrypoint.py"]

--- a/demos/ecosystem-mock/mock_ecosystem/entrypoint.py
+++ b/demos/ecosystem-mock/mock_ecosystem/entrypoint.py
@@ -1,0 +1,184 @@
+"""
+O.A.S.I.S. ecosystem mock — runs simulated components that publish and
+subscribe to each other over MQTT, demonstrating the full ecosystem on
+a single machine.
+
+Simulated components:
+  - A.U.R.A. (helmet sensors) — publishes motion, GPS, environmental data
+  - S.T.A.T. (system monitor) — publishes system metrics, battery status
+  - S.C.O.P.E. coordination — OCP E4 software peer, monitors all topics
+  - Home Assistant mock — smart home entity control
+  - LLM mock — OpenAI-compatible keyword → tool call mapping
+
+Each component runs as an OCP peer with E4 (software) embodiment,
+publishing status and discovery messages so D.A.W.N. and M.I.R.A.G.E.
+can discover them on the network.
+
+Environment variables:
+  MQTT_BROKER (default "mqtt-broker")
+  MQTT_PORT (default 1883)
+  HA_PORT (default 8123)
+  LLM_PORT (default 8080)
+  PUBLISH_INTERVAL (default 1.0 seconds)
+"""
+
+import json
+import os
+import signal
+import sys
+import threading
+import time
+
+import paho.mqtt.client as mqtt
+
+from simulation.layer0.sensor import MockSensor
+from simulation.layer1.mqtt import TopicBuilder, MessageSerializer
+from simulation.layer1.ocp import OCPPeer, Embodiment
+from simulation.layer2.ha_mock import HomeAssistantMock
+from simulation.layer2.llm_mock import LLMMock
+from simulation.layer2.llm_http_server import LLMHTTPServer
+
+
+def create_sensor_publisher(client, interval):
+    """Publish simulated A.U.R.A. and S.T.A.T. sensor data at regular intervals."""
+    imu = MockSensor("imu", sensor_type="motion")
+    gps = MockSensor("gps", sensor_type="gps")
+    enviro = MockSensor("enviro", sensor_type="environmental")
+
+    def publish_loop():
+        while True:
+            # A.U.R.A. topics — same JSON schemas M.I.R.A.G.E. expects
+            motion = imu.read()
+            client.publish("aura", json.dumps(motion))
+
+            gps_data = gps.read()
+            client.publish("aura", json.dumps(gps_data))
+
+            enviro_data = enviro.read()
+            client.publish("aura", json.dumps(enviro_data))
+
+            # S.T.A.T. topics — system metrics
+            client.publish("stat", json.dumps({
+                "device": "SystemMetrics",
+                "cpu_percent": 35.2 + (time.time() % 10),
+                "memory_percent": 62.1,
+                "disk_percent": 45.0,
+                "system_temp": 52.3,
+                "uptime_seconds": int(time.time()) % 86400,
+            }))
+            client.publish("stat", json.dumps({
+                "device": "BatteryStatus",
+                "voltage": 12.4,
+                "current": 1.2,
+                "power": 14.88,
+                "percentage": 85,
+                "charging": False,
+            }))
+
+            time.sleep(interval)
+
+    t = threading.Thread(target=publish_loop, daemon=True)
+    t.start()
+    return t
+
+
+def main():
+    broker = os.environ.get("MQTT_BROKER", "mqtt-broker")
+    port = int(os.environ.get("MQTT_PORT", "1883"))
+    ha_port = int(os.environ.get("HA_PORT", "8123"))
+    llm_port = int(os.environ.get("LLM_PORT", "8080"))
+    interval = float(os.environ.get("PUBLISH_INTERVAL", "1.0"))
+
+    # --- MQTT client ---
+    client = mqtt.Client(mqtt.CallbackAPIVersion.VERSION2)
+    client.connect(broker, port, 60)
+    client.loop_start()
+
+    # --- OCP peers (E4 software embodiment) ---
+    aura_peer = OCPPeer(
+        client=client,
+        peer_id="echo-aura-simulation",
+        component="aura",
+        embodiment=Embodiment.E4,
+        capabilities=["motion", "gps", "environmental"],
+        version="0.1.0-simulation",
+    )
+
+    stat_peer = OCPPeer(
+        client=client,
+        peer_id="echo-stat-simulation",
+        component="stat",
+        embodiment=Embodiment.E4,
+        capabilities=["system_metrics", "battery"],
+        version="0.1.0-simulation",
+    )
+
+    scope_peer = OCPPeer(
+        client=client,
+        peer_id="echo-scope-simulation",
+        component="scope",
+        embodiment=Embodiment.E4,
+        capabilities=["coordination", "monitoring"],
+        version="0.1.0-simulation",
+    )
+
+    # --- Start OCP peers ---
+    for peer in [aura_peer, stat_peer, scope_peer]:
+        peer.start()
+        print(f"  OCP peer online: {peer.peer_id} ({peer.component})")
+
+    # --- Start sensor publisher ---
+    create_sensor_publisher(client, interval)
+    print(f"  Sensor publisher: aura + stat topics at {interval}s intervals")
+
+    # --- Home Assistant Mock ---
+    ha = HomeAssistantMock(host="0.0.0.0", port=ha_port)
+    ha.start()
+    print(f"  Home Assistant mock: http://0.0.0.0:{ha_port}")
+
+    # --- LLM Mock ---
+    llm = LLMMock(default_response="I'm not sure how to help with that.")
+    llm.add_tool_rule("turn on the kitchen lights",
+        tool="homeassistant", args={"action": "turn_on", "entity_id": "light.kitchen_lights"})
+    llm.add_tool_rule("turn off the kitchen lights",
+        tool="homeassistant", args={"action": "turn_off", "entity_id": "light.kitchen_lights"})
+    llm.add_tool_rule("turn on the bedroom lights",
+        tool="homeassistant", args={"action": "turn_on", "entity_id": "light.bedroom_lights"})
+    llm.add_tool_rule("turn off the bedroom lights",
+        tool="homeassistant", args={"action": "turn_off", "entity_id": "light.bedroom_lights"})
+    llm.add_tool_rule("set thermostat",
+        tool="homeassistant", args={"action": "set_temperature", "entity_id": "climate.living_room_thermostat", "temperature": 22})
+    llm.add_rule("hello", "Hey! I'm the O.A.S.I.S. ecosystem running in full simulation mode.")
+    llm.add_rule("status", "All simulated peers online: A.U.R.A. (sensors), S.T.A.T. (system), S.C.O.P.E. (coordination). HA mock active. MQTT broker connected.")
+
+    llm_server = LLMHTTPServer(llm, host="0.0.0.0", port=llm_port)
+    llm_server.start()
+    print(f"  LLM mock: http://0.0.0.0:{llm_port}")
+
+    print(f"\nO.A.S.I.S. ecosystem simulation ready.")
+    print(f"  MQTT broker: {broker}:{port}")
+    print(f"  OCP peers: echo-aura-simulation, echo-stat-simulation, echo-scope-simulation")
+    print(f"  Sensor data: aura (motion/GPS/enviro) + stat (metrics/battery)")
+    print(f"  Smart home: kitchen lights, bedroom lights, thermostat")
+    print(f"\nConnect D.A.W.N. or M.I.R.A.G.E. to this network to see the full ecosystem.")
+
+    # --- Wait for shutdown ---
+    def shutdown(signum, frame):
+        print("\nShutting down ecosystem simulation...")
+        for peer in [aura_peer, stat_peer, scope_peer]:
+            peer.stop()
+        llm_server.stop()
+        ha.stop()
+        client.loop_stop()
+        client.disconnect()
+        sys.exit(0)
+
+    signal.signal(signal.SIGTERM, shutdown)
+    signal.signal(signal.SIGINT, shutdown)
+
+    while True:
+        time.sleep(1)
+
+
+if __name__ == "__main__":
+    main()

--- a/demos/ecosystem-mock/mock_ecosystem/requirements.txt
+++ b/demos/ecosystem-mock/mock_ecosystem/requirements.txt
@@ -1,0 +1,3 @@
+flask>=3.0
+paho-mqtt>=1.6.1
+websockets>=11.0

--- a/demos/ecosystem-mock/mosquitto.conf
+++ b/demos/ecosystem-mock/mosquitto.conf
@@ -1,0 +1,2 @@
+listener 1883
+allow_anonymous true


### PR DESCRIPTION
## Summary
Docker Compose demo that runs the full O.A.S.I.S. ecosystem on a single machine with all components simulated by the E.C.H.O. framework:

- OCP E4 software peers: A.U.R.A. (sensors), S.T.A.T. (system metrics), S.C.O.P.E. (coordination) — with status, discovery, and heartbeat
- Sensor publisher: motion/GPS/environmental on `aura` topic, CPU/memory/battery on `stat` topic at ~1Hz
- Home Assistant mock: smart home entity control (kitchen/bedroom lights, thermostat)
- LLM mock: OpenAI-compatible endpoint with keyword → tool call mapping
- MQTT broker: shared network for all components

D.A.W.N. and M.I.R.A.G.E. can optionally connect to the same MQTT network to exercise the full cross-component pipeline. No GPU, no API keys, no external services. ~500 MB Docker image.

## Type of Change
- [x] New feature
- [x] Documentation
- [ ] Bug fix
- [ ] Refactoring

## Testing
- [ ] `docker compose -f demos/ecosystem-mock/docker-compose.demo.yaml up --build` starts all services
- [ ] MQTT topics (`aura`, `stat`, `*/status`, `echo/discovery/simulates`) populated at ~1Hz
- [ ] HA mock: `curl -H "Authorization: Bearer mock-ha-token" http://localhost:8123/api/states` returns entities
- [ ] LLM mock: `curl http://localhost:8080/v1/models` returns model list
- [ ] OCP peers publish retained status and discovery messages

## Checklist
- [x] Documentation updated (demos/ecosystem-mock/README.md)
- [x] No breaking changes

**Stacked on**: PR #37 (ADR-0007)
Closes #40
Tracked by: #30 (simulation environment)

---
🤖 Generated with [Claude Code](https://claude.ai/code)
